### PR TITLE
Added joke controller and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Lab instructions: <https://ucsb-cs156.github.io/s24/lab/team01.html>
 |  Yusheng  | WhrainySu       | `TidesQueryService`         | `TidesController`         |
 |  Kriteen  | kriteenshrestha | `UniversityQueryService`    | `UniversityController`    |
 |  Kelly    | kmflippo        | `ZipCodeQueryService`       | `ZipCodeController`       |
+|  Julia    | jchanDev        | `JokeQueryService`          | `JokeController`          |
 ```
 
 Repo: https://github.com/ucsb-cs156-s24/team01-s24-4pm-2

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
@@ -36,7 +36,7 @@ public class JokeController {
         @Parameter(name="Category", description="category of joke", example="Programming") @RequestParam String category
     ) throws JsonProcessingException {
         log.info("getJokes: amount={} Category={}", amount, category);
-        String result = jokeQueryService.getJSON(amount, Integer.valueOf(category));
+        String result = jokeQueryService.getJSON(category, Integer.valueOf(amount));
         return ResponseEntity.ok().body(result);
     }
 

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
@@ -36,7 +36,7 @@ public class JokeController {
         @Parameter(name="Category", description="category of joke", example="Programming") @RequestParam String category
     ) throws JsonProcessingException {
         log.info("getJokes: amount={} Category={}", amount, category);
-        String result = jokeQueryService.getJSON(category, Integer.valueOf(amount));
+        String result = jokeQueryService.getJSON(category, amount);
         return ResponseEntity.ok().body(result);
     }
 

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
@@ -2,7 +2,43 @@ package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Jokes from https://v2.jokeapi.dev/")
+@Slf4j
 @RestController
+@RequestMapping("/api/jokes")
 public class JokeController {
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    JokeQueryService jokeQueryService;
+
+    @Operation(summary = "Get jokes for a given category and amount")
+    @GetMapping("/get")
+    public ResponseEntity<String> getEarthquakes(
+        @Parameter(name="amount", description="amount of jokes to get", example="2") @RequestParam String amount,
+        @Parameter(name="Category", description="category of joke", example="Programming") @RequestParam String category
+    ) throws JsonProcessingException {
+        log.info("getJokes: amount={} Category={}", amount, category);
+        String result = jokeQueryService.getJSON(amount, Integer.valueOf(category));
+        return ResponseEntity.ok().body(result);
+    }
+
     
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
@@ -33,9 +33,9 @@ public class JokeController {
     @GetMapping("/get")
     public ResponseEntity<String> getEarthquakes(
         @Parameter(name="amount", description="amount of jokes to get", example="2") @RequestParam String amount,
-        @Parameter(name="Category", description="category of joke", example="Programming") @RequestParam String category
+        @Parameter(name="category", description="category of joke", example="Programming") @RequestParam String category
     ) throws JsonProcessingException {
-        log.info("getJokes: amount={} Category={}", amount, category);
+        log.info("getJokes: amount={} category={}", amount, category);
         String result = jokeQueryService.getJSON(category, amount);
         return ResponseEntity.ok().body(result);
     }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
@@ -31,7 +31,7 @@ public class JokeController {
 
     @Operation(summary = "Get jokes for a given category and amount")
     @GetMapping("/get")
-    public ResponseEntity<String> getEarthquakes(
+    public ResponseEntity<String> getJoke(
         @Parameter(name="amount", description="amount of jokes to get", example="2") @RequestParam String amount,
         @Parameter(name="category", description="category of joke", example="Programming") @RequestParam String category
     ) throws JsonProcessingException {

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -40,6 +40,17 @@ public class JokeQueryService {
         HttpEntity<String> entity = new HttpEntity<>(headers);
         ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
                 uriVariables);
+        System.out.print(re.getBody());
+        System.out.println(" ");
+        System.out.println(" ");
+        System.out.println(" ");
+        System.out.println(" ");
+        System.out.println(" ");
+        System.out.println(" ");
+        System.out.println(" ");
+        System.out.println(" ");
+
+        
         return re.getBody();
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -40,17 +40,6 @@ public class JokeQueryService {
         HttpEntity<String> entity = new HttpEntity<>(headers);
         ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
                 uriVariables);
-        System.out.print(re.getBody());
-        System.out.println(" ");
-        System.out.println(" ");
-        System.out.println(" ");
-        System.out.println(" ");
-        System.out.println(" ");
-        System.out.println(" ");
-        System.out.println(" ");
-        System.out.println(" ");
-
-        
         return re.getBody();
     }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
 @Slf4j
+@Service
 public class JokeQueryService {
     ObjectMapper mapper = new ObjectMapper();
 
@@ -35,7 +36,7 @@ public class JokeQueryService {
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
-        Map<String, String> uriVariables = Map.of("amount", String.valueOf(numJokes),"category", category);
+        Map<String, String> uriVariables = Map.of("category", category, "numJokes", String.valueOf(numJokes));
         HttpEntity<String> entity = new HttpEntity<>(headers);
         ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
                 uriVariables);

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -31,12 +31,12 @@ public class JokeQueryService {
 
     public static final String ENDPOINT = "https://v2.jokeapi.dev/joke/{category}?amount={numJokes}";
 
-    public String getJSON(String category, int numJokes) throws HttpClientErrorException {
+    public String getJSON(String category, String numJokes) throws HttpClientErrorException {
         log.info("category={}, numJokes={}", category, numJokes);
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
-        Map<String, String> uriVariables = Map.of("category", category, "numJokes", String.valueOf(numJokes));
+        Map<String, String> uriVariables = Map.of("category", category, "numJokes", numJokes);
         HttpEntity<String> entity = new HttpEntity<>(headers);
         ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
                 uriVariables);

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
@@ -42,10 +42,10 @@ public class JokeControllerTests {
   
     String fakeJsonResult="{ \"fake\" : \"result\" }";
     String category = "Programming";
-    int numJokes = 2;
+    String numJokes = "2";
     when(mockJokeQueryService.getJSON(eq(category),eq(numJokes))).thenReturn(fakeJsonResult);
 
-    String url = String.format("/api/jokes/get?amount=%s&category=%s",String.valueOf(numJokes), category);
+    String url = String.format("/api/jokes/get?amount=%s&category=%s",numJokes, category);
 
     MvcResult response = mockMvc
         .perform( get(url).contentType("application/json"))

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
@@ -1,0 +1,59 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+
+
+@WebMvcTest(value = JokeController.class)
+public class JokeControllerTests {
+  private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  JokeQueryService mockJokeQueryService;
+
+
+  @Test
+  public void test_getJoke() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String category = "Programming";
+    int numJokes = 2;
+    when(mockJokeQueryService.getJSON(eq(category),eq(numJokes))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/jokes/get?amount=%s&category=%s",String.valueOf(numJokes), category);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
@@ -1,0 +1,43 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(JokeQueryService.class)
+public class JokeQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private JokeQueryService JokeQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        String category = "Programming";
+        int numJokes = 2;
+        String expectedURL = JokeQueryService.ENDPOINT.replace("{category}", category)
+                .replace("{numJokes}", String.valueOf(numJokes));
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = JokeQueryService.getJSON(category, numJokes);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
@@ -26,7 +26,7 @@ public class JokeQueryServiceTests {
     public void test_getJSON() {
 
         String category = "Programming";
-        int numJokes = 2;
+        String numJokes = "2";
         String expectedURL = JokeQueryService.ENDPOINT.replace("{category}", category)
                 .replace("{numJokes}", String.valueOf(numJokes));
 


### PR DESCRIPTION
In this PR, we add an endpoint `/api/jokes/get` that can be used to get jokes on various categories.

The code is deployed to dokku at http://team01-jchandev-dev.dokku-02.cs.ucsb.edu/.

Closes #35 